### PR TITLE
resolved PHP warnings when converting object to array

### DIFF
--- a/src/pkg_externallogin/com_externallogin/admin/models/server.php
+++ b/src/pkg_externallogin/com_externallogin/admin/models/server.php
@@ -103,11 +103,11 @@ class ExternalloginModelServer extends JModelAdmin
 		$data = JFactory::getApplication()->getUserState('com_externallogin.edit.server.data', array());
 		if (empty($data)) 
 		{
-			$data = (array) $this->getItem();
+			$data = $this->getItem();
 		}
-		if (empty($data['plugin']))
+		if (empty($data->plugin))
 		{
-			$data['plugin'] = $this->getState($this->getName() . '.plugin');
+			$data->plugin = $this->getState($this->getName() . '.plugin');
 		}
 		return $data;
 	}


### PR DESCRIPTION
SimpleXMLElement::xpath() is throwing two warnings;
- Warning: SimpleXMLElement::xpath() [simplexmlelement.xpath]: Unfinished literal
- Warning: SimpleXMLElement::xpath() [simplexmlelement.xpath]: xmlXPathEval: evaluation failed

Leaving the item as an object (rather than casting as an array) resolves the problem.
