### PR TITLE
Fix Authorize issue for new user

### DIFF
--- a/src/pkg_externallogin/plg_authentication_externallogin/externallogin.php
+++ b/src/pkg_externallogin/plg_authentication_externallogin/externallogin.php
@@ -299,6 +299,7 @@ class PlgAuthenticationExternallogin extends JPlugin
 
 					$response->status = JAuthentication::STATUS_UNKNOWN;
 				}
+				JAccess::clearStatics();
 			}
 			else
 			{


### PR DESCRIPTION
# Situation

- Saving new user will make user group be [cached](https://github.com/joomla/joomla-cms/blob/65b0f54459a2c74034c46ae7faf3d06b3d005418/libraries/src/Access/Access.php#L934)
- It will cause authorize fail during [onUserLogin](https://github.com/joomla/joomla-cms/blob/d434df342f6b927e0f5d51a7ca464ef95abc9886/plugins/user/joomla/joomla.php#L213) event

# Solution

[Clear static caches](https://github.com/joomla/joomla-cms/blob/65b0f54459a2c74034c46ae7faf3d06b3d005418/libraries/src/Access/Access.php#L139) after new user saved


