### PR TITLE
Ignore the composer vendor folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 build
 *~
 .gitignore
-
+/vendor/


### PR DESCRIPTION
See https://github.com/github/gitignore/blob/master/Composer.gitignore

And should we [commit the composer.lock](https://getcomposer.org/doc/01-basic-usage.md#commit-your-composer-lock-file-to-version-control) file to version control?

 