### PR TITLE
Fix nested ternary expressions (without parentheses) deprecated since PHP 7.4

### DIFF
--- a/src/pkg_externallogin/com_externallogin/admin/views/server/view.html.php
+++ b/src/pkg_externallogin/com_externallogin/admin/views/server/view.html.php
@@ -85,7 +85,7 @@ class ExternalloginViewServer extends JViewLegacy
 		$userId = $user->get('id');
 		$isNew = $this->item->id == 0;
 		$checkedOut = !($this->item->checked_out == 0 || $this->item->checked_out == $userId);
-		$type = $checkedOut ? 'view' : $isNew ? 'new' : 'edit';
+		$type = ($checkedOut ? 'view' : $isNew) ? 'new' : 'edit';
 
 		// Set the title
 		JToolBarHelper::title(JText::_('COM_EXTERNALLOGIN_MANAGER_SERVER_' . $type), 'server-' . $type);


### PR DESCRIPTION
- https://wiki.php.net/rfc/ternary_associativity